### PR TITLE
Add /rtp and /randomtp aliases

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -7,7 +7,7 @@ commands:
   wild:
     description: A command to randomly teleport
     usage: /<command>
-    aliases: [random]
+    aliases: [random, rtp]
 permissions:
   jwildtp.wild:
     description: Allows a player to randomly teleport

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -7,7 +7,7 @@ commands:
   wild:
     description: A command to randomly teleport
     usage: /<command>
-    aliases: [random, rtp]
+    aliases: [random, randomtp, rtp]
 permissions:
   jwildtp.wild:
     description: Allows a player to randomly teleport


### PR DESCRIPTION
Small change, but I feel like this should reduce the amount of players saying "how do i random tp" or "how do i start" in chat. Personally i had the muscle memory to use /rtp from other plugins before I started playing on RMC